### PR TITLE
Pass ddof=0 to np.cov in KernelDensity.fit

### DIFF
--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -245,7 +245,17 @@ class KernelDensity(BaseEstimator):
             self._cov = np.eye(X.shape[1])
             self._cho_cov = np.eye(X.shape[1])
         else:
-            self._cov = np.atleast_2d(np.cov(X.T, aweights=sample_weight))
+            # Since `sample_weight` can have floating point values, we need to
+            # pass them to `numpy.cov` as `aweights` instead of `fweights`:
+            # `fweights` only accepts integer values.
+            #
+            # However, we also want `KernelDensity` to handle sample weights in
+            # a similar way to other estimators in scikit-learn: fitting with
+            # integer valued `sample_weight` (even with a float-based dtype)
+            # should be equivalent to fitting with an equivalent repetitions
+            # instead. Therefore using `ddof=0` is important to ensure that
+            # this invariance property holds.
+            self._cov = np.atleast_2d(np.cov(X.T, aweights=sample_weight, ddof=0))
             self._cho_cov = cholesky(self._cov, lower=True)
 
         kwargs = self.metric_params

--- a/sklearn/neighbors/_kde.py
+++ b/sklearn/neighbors/_kde.py
@@ -220,8 +220,7 @@ class KernelDensity(BaseEstimator):
             sample_weight = _check_sample_weight(
                 sample_weight, X, dtype=np.float64, ensure_non_negative=True
             )
-            normalized_sample_weight = sample_weight / sample_weight.sum()
-            n_effective_samples = 1 / np.sum(normalized_sample_weight**2)
+            n_effective_samples = sample_weight.sum()
         else:
             n_effective_samples = X.shape[0]
 
@@ -398,10 +397,3 @@ class KernelDensity(BaseEstimator):
                 / np.sqrt(s_sq)
             )
             return data[i] + X * correction[:, np.newaxis]
-
-    def __sklearn_tags__(self):
-        tags = super().__sklearn_tags__()
-        tags._xfail_checks = {
-            "check_sample_weights_invariance": "sample_weight must have positive values"
-        }
-        return tags

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -16,7 +16,7 @@ from sklearn.utils._testing import assert_allclose
 
 # XXX Duplicated in test_neighbors_tree, test_kde
 def compute_kernel_slow(Y, X, kernel, h):
-    cho_cov = cholesky(np.cov(X.T), lower=True)
+    cho_cov = cholesky(np.cov(X.T, ddof=0), lower=True)
     X_scaled = solve_triangular(cho_cov, X.T, lower=True).T
     Y_scaled = solve_triangular(cho_cov, Y.T, lower=True).T
 

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -204,9 +204,9 @@ def test_kde_sample_weights(algorithm, metric, d):
     scores_ref_sampling = kde.score_samples(test_points)
     sample_ref_sampling = kde.sample(random_state=1234)
     assert_allclose(
-        np.exp(scores_weight), np.exp(scores_ref_sampling), atol=1e-8, rtol=1e-2
+        np.exp(scores_weight), np.exp(scores_ref_sampling), atol=1e-8, rtol=1e-6
     )
-    assert_allclose(sample_weight, sample_ref_sampling, rtol=1e-2)
+    assert_allclose(sample_weight, sample_ref_sampling, rtol=1e-6)
 
     # Test that sample weights has a non-trivial effect
     diff = np.max(np.abs(scores_no_weight - scores_weight))

--- a/sklearn/neighbors/tests/test_kde.py
+++ b/sklearn/neighbors/tests/test_kde.py
@@ -229,7 +229,7 @@ def test_kde_sample_weights(algorithm, metric, d, global_random_seed, bandwidth)
     scores_repetition = kde.score_samples(test_points)
     sample_repetition = kde.sample(random_state=1234)
     bandwidth_repetition = kde.bandwidth_
-    assert_allclose(np.exp(scores_weight), np.exp(scores_repetition), **tols)
+    assert_allclose(scores_weight, scores_repetition, **tols)
     assert_allclose(sample_weight, sample_repetition, **tols)
     assert bandwdith_weight == pytest.approx(bandwidth_repetition)
 


### PR DESCRIPTION
Attempt to improve `sample_weight` equivalence properties for scikit-learn/scikit-learn#27971.
